### PR TITLE
feat(Production Plan): Include Safety Stock in Required Qty Calculation

### DIFF
--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
@@ -15,6 +15,7 @@
   "uom",
   "projected_qty",
   "actual_qty",
+  "safety_stock",
   "item_details",
   "description",
   "min_order_qty",
@@ -129,11 +130,17 @@
    "fieldtype": "Link",
    "label": "From Warehouse",
    "options": "Warehouse"
+  },
+  {
+   "fetch_from": "item_code.safety_stock",
+   "fieldname": "safety_stock",
+   "fieldtype": "Float",
+   "label": "Safety Stock"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-02-03 12:22:29.913302",
+ "modified": "2021-03-08 18:39:17.553611",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Material Request Plan Item",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -32,6 +32,7 @@
   "material_request_planning",
   "include_non_stock_items",
   "include_subcontracted_items",
+  "include_safety_stock",
   "ignore_existing_ordered_qty",
   "column_break_25",
   "for_warehouse",
@@ -309,13 +310,19 @@
    "fieldtype": "Select",
    "label": "Sales Order Status",
    "options": "\nTo Deliver and Bill\nTo Bill\nTo Deliver"
+  },
+  {
+   "default": "0",
+   "fieldname": "include_safety_stock",
+   "fieldtype": "Check",
+   "label": "Include Safety Stock in Required Qty Calculation"
   }
  ],
  "icon": "fa fa-calendar",
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-11-10 18:01:54.991970",
+ "modified": "2021-03-08 11:17:25.470147",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",


### PR DESCRIPTION
While creating a Production Plan, sometimes we need to include safety stock to calculate Required Qty. There is a Safety Stock field in the Item Master which indicates the minimum amount of stock that should be present.

Added a field to show Safety Stock in the Material Request Item table in Production Plan.
If **_Include Safety Stock in Required Qty Calculation_** is checked, then, the safety stock configured in the Item master will be added to the respective item's required qty.

![safety_stock](https://user-images.githubusercontent.com/24353136/110344217-47318280-8053-11eb-973a-8f5652a2dae4.png)
