### PR TITLE
feat(Production Plan): Add more fields to Required Materials Download 

### DIFF
--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
@@ -11,6 +11,7 @@
   "from_warehouse",
   "warehouse",
   "column_break_4",
+  "required_bom_qty",
   "quantity",
   "uom",
   "projected_qty",
@@ -137,7 +138,9 @@
    "fetch_from": "item_code.safety_stock",
    "fieldname": "safety_stock",
    "fieldtype": "Float",
-   "label": "Safety Stock"
+   "label": "Safety Stock",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "ordered_qty",
@@ -152,11 +155,18 @@
    "label": "Reserved Qty for Production",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "required_bom_qty",
+   "fieldtype": "Float",
+   "label": "Required Qty as per BOM",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-03-22 12:11:10.993737",
+ "modified": "2021-03-26 12:41:13.013149",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Material Request Plan Item",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -251,7 +251,8 @@ frappe.ui.form.on('Production Plan', {
 
 	get_items_for_material_requests: function(frm, warehouses) {
 		const set_fields = ['actual_qty', 'item_code','item_name', 'description', 'uom', 'from_warehouse',
-			'min_order_qty', 'quantity', 'sales_order', 'warehouse', 'projected_qty', 'material_request_type'];
+			'min_order_qty', 'quantity', 'sales_order', 'warehouse', 'projected_qty', 'ordered_qty',
+			'reserved_qty_for_production', 'material_request_type'];
 
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.production_plan.production_plan.get_items_for_material_requests",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -251,7 +251,7 @@ frappe.ui.form.on('Production Plan', {
 
 	get_items_for_material_requests: function(frm, warehouses) {
 		const set_fields = ['actual_qty', 'item_code','item_name', 'description', 'uom', 'from_warehouse',
-			'min_order_qty', 'quantity', 'sales_order', 'warehouse', 'projected_qty', 'ordered_qty',
+			'min_order_qty', 'required_bom_qty', 'quantity', 'sales_order', 'warehouse', 'projected_qty', 'ordered_qty',
 			'reserved_qty_for_production', 'material_request_type'];
 
 		frappe.call({

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -625,7 +625,8 @@ def get_bin_details(row, company, for_warehouse=None, all_warehouse=False):
 		""".format(lft, rgt, company)
 
 	return frappe.db.sql(""" select ifnull(sum(projected_qty),0) as projected_qty,
-		ifnull(sum(actual_qty),0) as actual_qty, warehouse from `tabBin`
+		ifnull(sum(actual_qty),0) as actual_qty, ifnull(sum(ordered_qty),0) as ordered_qty,
+		ifnull(sum(reserved_qty_for_production),0) as reserved_qty_for_production, warehouse from `tabBin`
 		where item_code = %(item_code)s {conditions}
 		group by item_code, warehouse
 	""".format(conditions=conditions), { "item_code": row['item_code'] }, as_dict=1)

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -434,14 +434,14 @@ def download_raw_materials(doc):
 	if isinstance(doc, string_types):
 		doc = frappe._dict(json.loads(doc))
 
-	item_list = [['Item Code', 'Description', 'Stock UOM', 'Required Qty', 'Warehouse',
+	item_list = [['Item Code', 'Description', 'Stock UOM', 'Warehouse', 'Required Qty as per BOM',
 		'Projected Qty', 'Actual Qty', 'Ordered Qty', 'Reserved Qty for Production',
-		'Safety Stock']]
+		'Safety Stock', 'Required Qty']]
 
 	for d in get_items_for_material_requests(doc):
-		item_list.append([d.get('item_code'), d.get('description'), d.get('stock_uom'), d.get('quantity'),
-			d.get('warehouse'), d.get('projected_qty'), d.get('actual_qty'), d.get('ordered_qty'),
-			d.get('reserved_qty_for_production'), d.get('safety_stock')])
+		item_list.append([d.get('item_code'), d.get('description'), d.get('stock_uom'), d.get('warehouse'),
+			d.get('required_bom_qty'), d.get('projected_qty'), d.get('actual_qty'), d.get('ordered_qty'),
+			d.get('reserved_qty_for_production'), d.get('safety_stock'), d.get('quantity')])
 
 		if not doc.get('for_warehouse'):
 			row = {'item_code': d.get('item_code')}
@@ -449,9 +449,9 @@ def download_raw_materials(doc):
 				if d.get("warehouse") == bin_dict.get('warehouse'):
 					continue
 
-				item_list.append(['', '', '', '', bin_dict.get('warehouse'),
-					bin_dict.get('projected_qty', 0), bin_dict.get('actual_qty', 0)],
-					bin_dict.get('ordered_qty', 0), bin_dict.get('reserved_qty_for_production', 0))
+				item_list.append(['', '', '', bin_dict.get('warehouse'), '',
+					bin_dict.get('projected_qty', 0), bin_dict.get('actual_qty', 0),
+					bin_dict.get('ordered_qty', 0), bin_dict.get('reserved_qty_for_production', 0)])
 
 	build_csv_response(item_list, doc.name)
 
@@ -554,6 +554,7 @@ def get_material_request_items(row, sales_order, company,
 			'item_code': row.item_code,
 			'item_name': row.item_name,
 			'quantity': required_qty,
+			'required_bom_qty': total_qty,
 			'description': row.description,
 			'stock_uom': row.get("stock_uom"),
 			'warehouse': warehouse or row.get('source_warehouse') \

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -435,11 +435,13 @@ def download_raw_materials(doc):
 		doc = frappe._dict(json.loads(doc))
 
 	item_list = [['Item Code', 'Description', 'Stock UOM', 'Required Qty', 'Warehouse',
-		'projected Qty', 'Actual Qty']]
+		'Projected Qty', 'Actual Qty', 'Ordered Qty', 'Reserved Qty for Production',
+		'Safety Stock']]
 
 	for d in get_items_for_material_requests(doc):
 		item_list.append([d.get('item_code'), d.get('description'), d.get('stock_uom'), d.get('quantity'),
-			d.get('warehouse'), d.get('projected_qty'), d.get('actual_qty')])
+			d.get('warehouse'), d.get('projected_qty'), d.get('actual_qty'), d.get('ordered_qty'),
+			d.get('reserved_qty_for_production'), d.get('safety_stock')])
 
 		if not doc.get('for_warehouse'):
 			row = {'item_code': d.get('item_code')}
@@ -448,7 +450,8 @@ def download_raw_materials(doc):
 					continue
 
 				item_list.append(['', '', '', '', bin_dict.get('warehouse'),
-					bin_dict.get('projected_qty', 0), bin_dict.get('actual_qty', 0)])
+					bin_dict.get('projected_qty', 0), bin_dict.get('actual_qty', 0)],
+					bin_dict.get('ordered_qty', 0), bin_dict.get('reserved_qty_for_production', 0))
 
 	build_csv_response(item_list, doc.name)
 
@@ -555,6 +558,7 @@ def get_material_request_items(row, sales_order, company,
 			'stock_uom': row.get("stock_uom"),
 			'warehouse': warehouse or row.get('source_warehouse') \
 				or row.get('default_warehouse') or item_group_defaults.get("default_warehouse"),
+			'safety_stock': row.safety_stock,
 			'actual_qty': bin_dict.get("actual_qty", 0),
 			'projected_qty': bin_dict.get("projected_qty", 0),
 			'ordered_qty': bin_dict.get("ordered_qty", 0),


### PR DESCRIPTION
- Added a field **Required Qty as per BOM** which shows the required qty of raw material as per BOM qty and Planned Qty

   ![required-bom-qty](https://user-images.githubusercontent.com/24353136/112601331-54fb4c00-8e38-11eb-8992-4a57a99ce07e.png)

- Added more fields to the **Required Materials Download**
   - Required Qty as per BOM
   - Ordered Qty
   - Safety Stock
   - Required Qty for Production
   
  ![download](https://user-images.githubusercontent.com/24353136/112601454-7e1bdc80-8e38-11eb-8d37-9d9290550215.png)

**Vikram Tea and ERPNext fields mapping:**

![vt](https://user-images.githubusercontent.com/24353136/112602231-6a24aa80-8e39-11eb-8cd8-39e778c1866e.png)
